### PR TITLE
Improve VRS 2 output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "tqdm",
     "click",
     "cool-seq-tool==0.4.0.dev3",
-    "ga4gh.vrs~=2.0.0-a6",
+    "ga4gh.vrs==2.0.0-a6",
     "gene_normalizer[etl,pg]==0.3.0-dev2",
     "pydantic>=2",
     "python-dotenv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "biopython",
     "tqdm",
     "click",
-    "cool-seq-tool>=0.4.0.dev1",
+    "cool-seq-tool==0.4.0.dev3",
     "ga4gh.vrs~=2.0.0-a6",
     "gene_normalizer[etl,pg]==0.3.0-dev2",
     "pydantic>=2",

--- a/src/dcd_mapping/annotate.py
+++ b/src/dcd_mapping/annotate.py
@@ -535,7 +535,7 @@ def save_mapped_output_json(
     _logger.info("Saving mapping output to %s", output_path)
     with output_path.open("w") as file:
         json.dump(
-            json.loads(output.model_dump_json(exclude_unset=True, exclude_none=True)),
+            output.model_dump(exclude_unset=True, exclude_none=True),
             file,
             indent=4,
         )

--- a/src/dcd_mapping/cli.py
+++ b/src/dcd_mapping/cli.py
@@ -9,6 +9,7 @@ import click
 from dcd_mapping.align import AlignmentError
 from dcd_mapping.main import map_scoreset_urn
 from dcd_mapping.resource_utils import ResourceAcquisitionError
+from dcd_mapping.schemas import VrsVersion
 from dcd_mapping.transcripts import TxSelectError
 from dcd_mapping.vrs_map import VrsMapError
 
@@ -33,11 +34,12 @@ _logger = logging.getLogger(__name__)
     help="Desired location at which output file should be saved",
 )
 @click.option(
-    "--include_vrs_2",
+    "--vrs_version",
     "-v",
-    is_flag=True,
-    default=False,
-    help="Include VRS 2.0 mappings",
+    type=click.Choice(["1.3", "2"]),
+    default="2",
+    show_default=True,
+    help="Version to use for output VRS objects",
 )
 @click.option(
     "--prefer_genomic",
@@ -49,7 +51,7 @@ def cli(
     urn: str,
     debug: bool,
     output: Path | None,
-    include_vrs_2: bool,
+    vrs_version: VrsVersion,
     prefer_genomic: bool,
 ) -> None:
     """Get VRS mapping on preferred transcript for URN.
@@ -72,7 +74,7 @@ def cli(
     _logger.debug("debug logging enabled")
     try:
         asyncio.run(
-            map_scoreset_urn(urn, output, include_vrs_2, prefer_genomic, silent=False)
+            map_scoreset_urn(urn, output, vrs_version, prefer_genomic, silent=False)
         )
     except (
         LookupError,

--- a/src/dcd_mapping/main.py
+++ b/src/dcd_mapping/main.py
@@ -15,6 +15,7 @@ from dcd_mapping.resource_utils import ResourceAcquisitionError
 from dcd_mapping.schemas import (
     ScoreRow,
     ScoresetMetadata,
+    VrsVersion,
 )
 from dcd_mapping.transcripts import TxSelectError, select_transcript
 from dcd_mapping.vrs_map import VrsMapError, vrs_map
@@ -123,7 +124,7 @@ async def map_scoreset(
     metadata: ScoresetMetadata,
     records: list[ScoreRow],
     output_path: Path | None = None,
-    include_vrs_2: bool = False,
+    vrs_version: VrsVersion = VrsVersion.V_2,
     prefer_genomic: bool = False,
     silent: bool = True,
 ) -> None:
@@ -177,13 +178,12 @@ async def map_scoreset(
     _emit_info("VRS mapping complete.", silent)
 
     _emit_info("Annotating metadata and saving to file...", silent)
-    vrs_results = annotate(vrs_results, transcript, metadata)
+    vrs_results = annotate(vrs_results, transcript, metadata, vrs_version)
     final_output = save_mapped_output_json(
         metadata.urn,
         vrs_results,
         alignment_result,
         transcript,
-        include_vrs_2,
         prefer_genomic,
         output_path,
     )
@@ -193,7 +193,7 @@ async def map_scoreset(
 async def map_scoreset_urn(
     urn: str,
     output_path: Path | None = None,
-    include_vrs_2: bool = False,
+    vrs_version: VrsVersion = VrsVersion.V_2,
     prefer_genomic: bool = False,
     silent: bool = True,
 ) -> None:
@@ -201,7 +201,7 @@ async def map_scoreset_urn(
 
     :param urn: identifier for a scoreset.
     :param output_path: optional path to save output at
-    :param include_vrs_2: if true, include VRS 2.0 mappings in output JSON
+    :param vrs_version: version of VRS objects to output (1.3 or 2)
     :param silent: if True, suppress console information output
     """
     try:
@@ -213,5 +213,5 @@ async def map_scoreset_urn(
         click.echo(f"Error: {msg}")
         raise e
     await map_scoreset(
-        metadata, records, output_path, include_vrs_2, prefer_genomic, silent
+        metadata, records, output_path, vrs_version, prefer_genomic, silent
     )

--- a/src/dcd_mapping/schemas.py
+++ b/src/dcd_mapping/schemas.py
@@ -24,6 +24,13 @@ class TargetType(str, Enum):
     OTHER_NC = "Other noncoding"
 
 
+class VrsVersion(str, Enum):
+    """Define VRS versions"""
+
+    V_1_3 = "1.3"
+    V_2 = "2"
+
+
 class UniProtRef(BaseModel):
     """Store metadata associated with MaveDB UniProt reference"""
 
@@ -157,10 +164,9 @@ class ScoreAnnotation(BaseModel):
     This model defines what an individual mapping instance looks like in the final JSON.
     """
 
-    pre_mapped: vrs_v1_schemas.VariationDescriptor | vrs_v1_schemas.Haplotype
-    post_mapped: vrs_v1_schemas.VariationDescriptor | vrs_v1_schemas.Haplotype
-    pre_mapped_2_0: Allele | Haplotype | None = None
-    post_mapped_2_0: Allele | Haplotype | None = None
+    pre_mapped: vrs_v1_schemas.VariationDescriptor | vrs_v1_schemas.Haplotype | Allele | Haplotype
+    post_mapped: vrs_v1_schemas.VariationDescriptor | vrs_v1_schemas.Haplotype | Allele | Haplotype
+    vrs_version: VrsVersion
     mavedb_id: StrictStr
     relation: Literal["SO:is_homologous_to"] = "SO:is_homologous_to"
     score: float | None


### PR DESCRIPTION
Provide expanded VRS 2 output which includes detailed location information.
Instead of providing a CLI option to include VRS 2 output in addition to VRS 1.3,
provide a CLI option to include either VRS 1.3 or VRS 2 output.
Make VRS 2 the default output.