### PR TITLE
Always Create a New Gene Normalizer Instance

### DIFF
--- a/src/dcd_mapping/lookup.py
+++ b/src/dcd_mapping/lookup.py
@@ -162,14 +162,17 @@ class GeneNormalizerBuilder:
     """Singleton constructor for Gene Normalizer instance."""
 
     def __new__(cls) -> QueryHandler:
-        """Provide Gene Normalizer instance. Construct it if unavailable.
+        """Provide Gene Normalizer instance. If an instance has already been
+        constructed, close its connection and provide a new one.
 
         :return: singleton instance of ``QueryHandler`` for Gene Normalizer
         """
-        if not hasattr(cls, "instance"):
-            db = create_db()
-            q = QueryHandler(db)
-            cls.instance = q
+        if hasattr(cls, "instance"):
+            cls.instance.db.close_connection()
+            cls.instance = None
+
+        db = create_db()
+        cls.instance = QueryHandler(db)
         return cls.instance
 
 


### PR DESCRIPTION
This is to avoid instances where the database connection has been prematurely closed. Since the gene normalizer instance uses an internal abstract database class and we don't expect this operation to occur too often, it is simpler to just close the existing database connection ourselves and respawn the instance in cases where it already exists.