### PR TITLE
Guarantee mapping output for all variants

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -30,7 +30,7 @@ services:
       - vrs-mapping-data-dev:/var/lib/postgresql/data
 
   seqrepo:
-    image: biocommons/seqrepo:2021-01-29
+    image: biocommons/seqrepo:2024-12-20
     volumes:
       - vrs-mapping-seqrepo-dev:/usr/local/share/seqrepo
 

--- a/settings/.env.dev
+++ b/settings/.env.dev
@@ -30,4 +30,4 @@ MAVEDB_API_KEY=
 # Environment variables for seqrepo
 ####################################################################################################
 
-SEQREPO_ROOT_DIR=/usr/local/share/seqrepo/2021-01-29
+SEQREPO_ROOT_DIR=/usr/local/share/seqrepo/2024-12-20

--- a/src/api/routers/map.py
+++ b/src/api/routers/map.py
@@ -68,6 +68,7 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
                 error_message="Score set contains no variants to map",
             ).model_dump(exclude_none=True)
         )
+    total_score_records = sum(len(v) for v in records.values())
 
     try:
         alignment_results = build_alignment_result(metadata, True)
@@ -120,13 +121,25 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
                 metadata=metadata, error_message=str(e).strip("'")
             ).model_dump(exclude_none=True)
         )
-    if not vrs_results or all(
-        mapping_result is None for mapping_result in vrs_results.values()
-    ):
+
+    nonetype_vrs_results = [
+        result is None
+        for target_gene in vrs_results
+        for result in vrs_results[target_gene]
+    ]
+
+    if not vrs_results or all(nonetype_vrs_results):
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata,
                 error_message="No variant mappings available for this score set",
+            ).model_dump(exclude_none=True)
+        )
+    if any(nonetype_vrs_results):
+        return JSONResponse(
+            content=ScoresetMapping(
+                metadata=metadata,
+                error_message="Some variants generated vrs results, but not all. If any variants were mapped, all should have been.",
             ).model_dump(exclude_none=True)
         )
 
@@ -146,13 +159,25 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
                 metadata=metadata, error_message=str(e).strip("'")
             ).model_dump(exclude_none=True)
         )
-    if not annotated_vrs_results or all(
-        mapping_result is None for mapping_result in annotated_vrs_results.values()
-    ):
+
+    nonetype_annotated_vrs_results = [
+        result is None
+        for target_gene in annotated_vrs_results
+        for result in annotated_vrs_results[target_gene]
+    ]
+
+    if not annotated_vrs_results or all(nonetype_annotated_vrs_results):
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata,
                 error_message="No annotated variant mappings available for this score set",
+            ).model_dump(exclude_none=True)
+        )
+    if any(nonetype_annotated_vrs_results):
+        return JSONResponse(
+            content=ScoresetMapping(
+                metadata=metadata,
+                error_message="Some variants generated annotated vrs results, but not all. If any variants were annotated, all should have been.",
             ).model_dump(exclude_none=True)
         )
 
@@ -232,6 +257,14 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata, error_message=str(e).strip("'")
+            ).model_dump(exclude_none=True)
+        )
+
+    if len(mapped_scores) != total_score_records:
+        return JSONResponse(
+            content=ScoresetMapping(
+                metadata=metadata,
+                error_message=f"Mismatch between number of mapped scores ({len(mapped_scores)}) and total score records ({total_score_records}). This is unexpected and indicates an issue with the mapping process.",
             ).model_dump(exclude_none=True)
         )
 

--- a/src/api/routers/map.py
+++ b/src/api/routers/map.py
@@ -16,10 +16,10 @@ from dcd_mapping.annotate import (
 from dcd_mapping.lookup import DataLookupError
 from dcd_mapping.mavedb_data import (
     ScoresetNotSupportedError,
-    correct_target_sequence_type,
     get_raw_scoreset_metadata,
     get_scoreset_metadata,
     get_scoreset_records,
+    patch_target_sequence_type,
     with_mavedb_score_set,
 )
 from dcd_mapping.resource_utils import ResourceAcquisitionError
@@ -49,7 +49,7 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
     try:
         metadata = get_scoreset_metadata(urn, store_path)
         records = get_scoreset_records(metadata, True, store_path)
-        metadata = correct_target_sequence_type(metadata, records)
+        metadata = patch_target_sequence_type(metadata, records)
     except ScoresetNotSupportedError as e:
         return JSONResponse(
             content=ScoresetMapping(

--- a/src/api/routers/map.py
+++ b/src/api/routers/map.py
@@ -13,6 +13,12 @@ from dcd_mapping.annotate import (
     _set_scoreset_layer,
     annotate,
 )
+from dcd_mapping.exceptions import (
+    MissingSequenceIdError,
+    UnsupportedReferenceSequenceNameSpaceError,
+    UnsupportedReferenceSequencePrefixError,
+    VrsMapError,
+)
 from dcd_mapping.lookup import DataLookupError
 from dcd_mapping.mavedb_data import (
     ScoresetNotSupportedError,
@@ -31,7 +37,7 @@ from dcd_mapping.schemas import (
     VrsVersion,
 )
 from dcd_mapping.transcripts import select_transcripts
-from dcd_mapping.vrs_map import VrsMapError, vrs_map
+from dcd_mapping.vrs_map import vrs_map
 
 router = APIRouter(
     prefix="/api/v1", tags=["mappings"], responses={404: {"description": "Not found"}}
@@ -115,7 +121,12 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
                 transcript=transcripts[target_gene],
                 silent=True,
             )
-    except VrsMapError as e:
+    except (
+        UnsupportedReferenceSequenceNameSpaceError,
+        VrsMapError,
+        UnsupportedReferenceSequencePrefixError,
+        MissingSequenceIdError,
+    ) as e:
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata, error_message=str(e).strip("'")

--- a/src/api/routers/map.py
+++ b/src/api/routers/map.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 from requests import HTTPError
 
-from dcd_mapping.align import AlignmentError, BlatNotFoundError, build_alignment_result
+from dcd_mapping.align import build_alignment_result
 from dcd_mapping.annotate import (
     _get_computed_reference_sequence,
     _get_mapped_reference_sequence,
@@ -14,21 +14,23 @@ from dcd_mapping.annotate import (
     annotate,
 )
 from dcd_mapping.exceptions import (
+    AlignmentError,
+    BlatNotFoundError,
+    DataLookupError,
     MissingSequenceIdError,
+    ResourceAcquisitionError,
+    ScoresetNotSupportedError,
     UnsupportedReferenceSequenceNameSpaceError,
     UnsupportedReferenceSequencePrefixError,
     VrsMapError,
 )
-from dcd_mapping.lookup import DataLookupError
 from dcd_mapping.mavedb_data import (
-    ScoresetNotSupportedError,
     get_raw_scoreset_metadata,
     get_scoreset_metadata,
     get_scoreset_records,
     patch_target_sequence_type,
     with_mavedb_score_set,
 )
-from dcd_mapping.resource_utils import ResourceAcquisitionError
 from dcd_mapping.schemas import (
     ScoreAnnotation,
     ScoresetMapping,

--- a/src/dcd_mapping/align.py
+++ b/src/dcd_mapping/align.py
@@ -12,12 +12,15 @@ from Bio.SearchIO import parse as parse_blat
 from Bio.SearchIO._model import Hit, QueryResult
 from cool_seq_tool.schemas import Strand
 
-from dcd_mapping.lookup import get_chromosome_identifier, get_gene_location
-from dcd_mapping.mavedb_data import LOCAL_STORE_PATH, ScoresetNotSupportedError
-from dcd_mapping.resource_utils import (
+from dcd_mapping.exceptions import (
+    AlignmentError,
+    BlatNotFoundError,
     ResourceAcquisitionError,
-    http_download,
+    ScoresetNotSupportedError,
 )
+from dcd_mapping.lookup import get_chromosome_identifier, get_gene_location
+from dcd_mapping.mavedb_data import LOCAL_STORE_PATH
+from dcd_mapping.resource_utils import http_download
 from dcd_mapping.schemas import (
     AlignmentResult,
     GeneLocation,
@@ -30,14 +33,6 @@ from dcd_mapping.schemas import (
 __all__ = ["align"]
 
 _logger = logging.getLogger(__name__)
-
-
-class AlignmentError(Exception):
-    """Raise when errors encountered during alignment."""
-
-
-class BlatNotFoundError(AlignmentError):
-    """Raise when BLAT binary appears to be missing."""
 
 
 def _write_query_file(file: Path, lines: list[str]) -> None:

--- a/src/dcd_mapping/annotate.py
+++ b/src/dcd_mapping/annotate.py
@@ -140,7 +140,7 @@ def _get_vrs_ref_allele_seq(
     metadata: TargetGene,
     urn: str,
     tx_select_results: TxSelectResult | None,
-) -> Extension:
+) -> Extension | None:
     """Create `vrs_ref_allele_seq` property."""
     start, end = _offset_allele_ref_seq(urn, allele.location.start, allele.location.end)
     if (
@@ -161,8 +161,12 @@ def _get_vrs_ref_allele_seq(
         seq = f"ga4gh:{allele.location.sequenceReference.refgetAccession}"  # type: ignore
         sr = get_seqrepo()
         ref = sr.get_sequence(seq, start, end)
-        if ref is None:
-            raise ValueError
+
+    if not ref:
+        msg = f"Could not retrieve reference sequence for allele {allele.id} in urn {urn} with start {start} and end {end}"
+        _logger.warning(msg)
+        return None
+
     return Extension(type="Extension", name="vrs_ref_allele_seq", value=ref)
 
 
@@ -256,9 +260,11 @@ def _annotate_allele_mapping(
     post_mapped: Allele = mapped_score.post_mapped
 
     # get vrs_ref_allele_seq for pre-mapped variants
-    pre_mapped.extensions = [
-        _get_vrs_ref_allele_seq(pre_mapped, metadata, urn, tx_results)
-    ]
+    ref_allele_seq_extension = _get_vrs_ref_allele_seq(
+        pre_mapped, metadata, urn, tx_results
+    )
+    if ref_allele_seq_extension is not None:
+        pre_mapped.extensions = [ref_allele_seq_extension]
 
     if post_mapped:
         # Determine reference sequence
@@ -313,9 +319,14 @@ def _annotate_haplotype_mapping(
     """Perform annotations and, if necessary, create VRS 1.3 equivalents for haplotype mappings."""
     pre_mapped: Haplotype = mapped_score.pre_mapped  # type: ignore
     post_mapped: Haplotype = mapped_score.post_mapped  # type: ignore
+
     # get vrs_ref_allele_seq for pre-mapped variants
     for allele in pre_mapped.members:
-        allele.extensions = [_get_vrs_ref_allele_seq(allele, metadata, urn, tx_results)]
+        ref_allele_seq_extension = _get_vrs_ref_allele_seq(
+            allele, metadata, urn, tx_results
+        )
+        if ref_allele_seq_extension is not None:
+            allele.extensions = [ref_allele_seq_extension]
 
     if post_mapped:
         # Determine reference sequence

--- a/src/dcd_mapping/annotate.py
+++ b/src/dcd_mapping/annotate.py
@@ -266,13 +266,16 @@ def _annotate_allele_mapping(
             sequence_id = f"ga4gh:{mapped_score.post_mapped.location.sequenceReference.refgetAccession}"
             accession = get_chromosome_identifier_from_vrs_id(sequence_id)
             if accession is None:
-                raise ValueError
-            if accession.startswith("refseq:"):
+                accession = None
+                mapped_score.error_message = "Could not determine accession for this annotation. No allele expression is available."
+            elif accession.startswith("refseq:"):
                 accession = accession[7:]
         else:
             if tx_results is None or isinstance(tx_results, TxSelectError):
-                raise ValueError  # impossible by definition
-            accession = tx_results.np
+                accession = None
+                mapped_score.error_message = "Could not determine accession for this annotation. No allele expression is available."
+            else:
+                accession = tx_results.np
 
         sr = get_seqrepo()
         loc = mapped_score.post_mapped.location
@@ -281,8 +284,9 @@ def _annotate_allele_mapping(
         post_mapped.extensions = [
             Extension(type="Extension", name="vrs_ref_allele_seq", value=ref)
         ]
-        hgvs_string, syntax = _get_hgvs_string(post_mapped, accession)
-        post_mapped.expressions = [Expression(syntax=syntax, value=hgvs_string)]
+        if accession:
+            hgvs_string, syntax = _get_hgvs_string(post_mapped, accession)
+            post_mapped.expressions = [Expression(syntax=syntax, value=hgvs_string)]
 
     if vrs_version == VrsVersion.V_1_3:
         pre_mapped = _allele_to_vod(pre_mapped)
@@ -295,9 +299,7 @@ def _annotate_allele_mapping(
         mavedb_id=mapped_score.accession_id,
         score=float(mapped_score.score) if mapped_score.score else None,
         annotation_layer=mapped_score.annotation_layer,
-        error_message=mapped_score.error_message
-        if mapped_score.error_message
-        else None,  # TODO might not need if statement here
+        error_message=mapped_score.error_message,
     )
 
 
@@ -321,13 +323,17 @@ def _annotate_haplotype_mapping(
             sequence_id = f"ga4gh:{post_mapped.members[0].location.sequenceReference.refgetAccession}"
             accession = get_chromosome_identifier_from_vrs_id(sequence_id)
             if accession is None:
-                raise ValueError
-            if accession.startswith("refseq:"):
+                accession = None
+                mapped_score.error_message = "Could not determine accession for this annotation. No allele expression is available."
+            elif accession.startswith("refseq:"):
                 accession = accession[7:]
         else:
             if tx_results is None or isinstance(tx_results, TxSelectError):
-                raise ValueError  # impossible by definition
-            accession = tx_results.np
+                # impossible by definition
+                accession = None
+                mapped_score.error_message = "Could not determine accession for this annotation. No allele expression is available."
+            else:
+                accession = tx_results.np
 
         sr = get_seqrepo()
         for allele in post_mapped.members:
@@ -337,8 +343,9 @@ def _annotate_haplotype_mapping(
             allele.extensions = [
                 Extension(type="Extension", name="vrs_ref_allele_seq", value=ref)
             ]
-            hgvs, syntax = _get_hgvs_string(allele, accession)
-            allele.expressions = [Expression(syntax=syntax, value=hgvs)]
+            if accession:
+                hgvs, syntax = _get_hgvs_string(allele, accession)
+                allele.expressions = [Expression(syntax=syntax, value=hgvs)]
 
     if vrs_version == VrsVersion.V_1_3:
         pre_mapped = _haplotype_to_haplotype_1_3(pre_mapped)
@@ -351,9 +358,7 @@ def _annotate_haplotype_mapping(
         mavedb_id=mapped_score.accession_id,
         score=float(mapped_score.score) if mapped_score.score is not None else None,
         annotation_layer=mapped_score.annotation_layer,
-        error_message=mapped_score.error_message
-        if mapped_score.error_message
-        else None,  # TODO might not need if statement here
+        error_message=mapped_score.error_message,
     )
 
 
@@ -388,6 +393,7 @@ def annotate(
                 ScoreAnnotationWithLayer(
                     mavedb_id=mapped_score.accession_id,
                     score=float(mapped_score.score) if mapped_score.score else None,
+                    vrs_version=vrs_version,
                     error_message=mapped_score.error_message,
                 )
             )
@@ -410,8 +416,16 @@ def annotate(
                 )
             )
         else:
-            # TODO how to combine this error message with other potential error messages?
-            ValueError("inconsistent variant structure")
+            score_annotations.append(
+                ScoreAnnotationWithLayer(
+                    pre_mapped=mapped_score.pre_mapped,
+                    post_mapped=mapped_score.post_mapped,
+                    vrs_version=vrs_version,
+                    mavedb_id=mapped_score.accession_id,
+                    score=float(mapped_score.score) if mapped_score.score else None,
+                    error_message=f"Multiple issues with annotation: Inconsistent variant structure (Allele and Haplotype mix).{' ' + mapped_score.error_message if mapped_score.error_message else ''}",
+                )
+            )
 
     return score_annotations
 
@@ -519,11 +533,6 @@ def _set_scoreset_layer(
     expressions. If genomic expressions are available, that's what we'd like to use.
     This function tells us how to filter the final annotation objects.
     """
-    if urn.startswith("urn:mavedb:00000097"):
-        _logger.debug(
-            "Manually selecting protein annotation for scores from urn:mavedb:00000097"
-        )
-        return AnnotationLayer.PROTEIN
     for mapping in mappings:
         if mapping.annotation_layer == AnnotationLayer.GENOMIC:
             return AnnotationLayer.GENOMIC

--- a/src/dcd_mapping/cli.py
+++ b/src/dcd_mapping/cli.py
@@ -7,11 +7,11 @@ from pathlib import Path
 import click
 
 from dcd_mapping.align import AlignmentError
+from dcd_mapping.exceptions import VrsMapError
 from dcd_mapping.main import map_scoreset_urn
 from dcd_mapping.resource_utils import ResourceAcquisitionError
 from dcd_mapping.schemas import VrsVersion
 from dcd_mapping.transcripts import TxSelectError
-from dcd_mapping.vrs_map import VrsMapError
 
 _logger = logging.getLogger(__name__)
 

--- a/src/dcd_mapping/cli.py
+++ b/src/dcd_mapping/cli.py
@@ -6,12 +6,14 @@ from pathlib import Path
 
 import click
 
-from dcd_mapping.align import AlignmentError
-from dcd_mapping.exceptions import VrsMapError
+from dcd_mapping.exceptions import (
+    AlignmentError,
+    ResourceAcquisitionError,
+    TxSelectError,
+    VrsMapError,
+)
 from dcd_mapping.main import map_scoreset_urn
-from dcd_mapping.resource_utils import ResourceAcquisitionError
 from dcd_mapping.schemas import VrsVersion
-from dcd_mapping.transcripts import TxSelectError
 
 _logger = logging.getLogger(__name__)
 

--- a/src/dcd_mapping/exceptions.py
+++ b/src/dcd_mapping/exceptions.py
@@ -1,6 +1,9 @@
 """Exceptions for DCD Mapping Module"""
 
 
+### Custom Exceptions for VRS Mapping Errors ###
+
+
 class VrsMapError(Exception):
     """Raise in case of generic VRS mapping errors."""
 
@@ -15,3 +18,42 @@ class MissingSequenceIdError(ValueError):
 
 class UnsupportedReferenceSequencePrefixError(ValueError):
     """Raised when a reference sequence prefix is not supported."""
+
+
+### Custom Exceptions for Alignment Errors ###
+
+
+class AlignmentError(ValueError):
+    """Raise when errors encountered during alignment."""
+
+
+class BlatNotFoundError(AlignmentError):
+    """Raise when BLAT binary appears to be missing."""
+
+
+### Custom Exceptions for Data Lookup Errors ###
+
+
+class DataLookupError(Exception):
+    """Raise for misc. issues related to resource acquisition/lookup."""
+
+
+### Custom Exceptions for MaveDB Data Errors ###
+
+
+class ScoresetNotSupportedError(ValueError):
+    """Raise when a score set cannot be mapped because it has characteristics that are not currently supported."""
+
+
+### Custom Exceptions for Resource Acquisition Errors ###
+
+
+class ResourceAcquisitionError(ValueError):
+    """Raise when resource acquisition fails."""
+
+
+### Custom Exceptions for Transcript Selection Errors ###
+
+
+class TxSelectError(ValueError):
+    """Raise for transcript selection failure."""

--- a/src/dcd_mapping/exceptions.py
+++ b/src/dcd_mapping/exceptions.py
@@ -1,0 +1,17 @@
+"""Exceptions for DCD Mapping Module"""
+
+
+class VrsMapError(Exception):
+    """Raise in case of generic VRS mapping errors."""
+
+
+class UnsupportedReferenceSequenceNameSpaceError(ValueError):
+    """Raised when a reference sequence name space is not supported."""
+
+
+class MissingSequenceIdError(ValueError):
+    """Raised when a sequence ID is not provided."""
+
+
+class UnsupportedReferenceSequencePrefixError(ValueError):
+    """Raised when a reference sequence prefix is not supported."""

--- a/src/dcd_mapping/lookup.py
+++ b/src/dcd_mapping/lookup.py
@@ -49,6 +49,7 @@ from gene.database import create_db
 from gene.query import QueryHandler
 from gene.schemas import MatchType, SourceName
 
+from dcd_mapping.exceptions import DataLookupError
 from dcd_mapping.schemas import (
     GeneLocation,
     ManeDescription,
@@ -91,10 +92,6 @@ def cdot_rest() -> RESTDataProvider:
 
 
 # ---------------------------------- Global ---------------------------------- #
-
-
-class DataLookupError(Exception):
-    """Raise for misc. issues related to resource acquisition/lookup."""
 
 
 class CoolSeqToolBuilder:
@@ -241,7 +238,9 @@ async def check_uta() -> None:
     query = f"select * from {uta.schema}.meta"  # noqa: S608
     result = await uta.execute_query(query)
     if not result:
-        raise DataLookupError
+        msg = "UTA schema check failed. No results returned."
+        _logger.error(msg)
+        raise DataLookupError(msg)
 
 
 async def get_protein_accession(transcript: str) -> str | None:
@@ -302,9 +301,13 @@ async def get_transcripts(
 def check_gene_normalizer() -> None:
     q = GeneNormalizerBuilder()
     if (not q.db.check_schema_initialized()) or not (q.db.check_tables_populated()):
-        raise DataLookupError
+        msg = "Gene Normalizer database schema check failed. No results returned."
+        _logger.error(msg)
+        raise DataLookupError(msg)
     if q.normalize("BRAF").match_type == MatchType.NO_MATCH:
-        raise DataLookupError
+        msg = "Gene Normalizer returned no normalization results for BRAF. This indicates an underlying issue with the database that should be investigated."
+        _logger.error(msg)
+        raise DataLookupError(msg)
 
 
 def _get_hgnc_symbol(term: str) -> str | None:
@@ -436,7 +439,9 @@ def get_gene_location(target_gene: TargetGene) -> GeneLocation | None:
 def check_seqrepo() -> None:
     sr = get_seqrepo()
     if not sr.sr["NC_000001.11"][780000:780020]:
-        raise DataLookupError
+        msg = "SeqRepo returned no sequence for NC_000001.11 at 780000:780020. This indicates an underlying issue with SeqRepo that should be investigated."
+        _logger.error(msg)
+        raise DataLookupError(msg)
     conn = sr.sr.aliases._db
     try:
         # conn = sr.sr.aliases._db

--- a/src/dcd_mapping/main.py
+++ b/src/dcd_mapping/main.py
@@ -22,9 +22,9 @@ from dcd_mapping.lookup import (
 )
 from dcd_mapping.mavedb_data import (
     ScoresetNotSupportedError,
-    correct_target_sequence_type,
     get_scoreset_metadata,
     get_scoreset_records,
+    patch_target_sequence_type,
     with_mavedb_score_set,
 )
 from dcd_mapping.resource_utils import ResourceAcquisitionError
@@ -333,7 +333,7 @@ async def map_scoreset_urn(
     try:
         metadata = get_scoreset_metadata(urn, store_path)
         records = get_scoreset_records(metadata, silent, store_path)
-        metadata = correct_target_sequence_type(metadata, records)
+        metadata = patch_target_sequence_type(metadata, records)
     except ScoresetNotSupportedError as e:
         _emit_info(f"Score set not supported: {e}", silent, logging.ERROR)
         final_output = write_scoreset_mapping_to_json(

--- a/src/dcd_mapping/main.py
+++ b/src/dcd_mapping/main.py
@@ -14,6 +14,12 @@ from dcd_mapping.annotate import (
     save_mapped_output_json,
     write_scoreset_mapping_to_json,
 )
+from dcd_mapping.exceptions import (
+    MissingSequenceIdError,
+    UnsupportedReferenceSequenceNameSpaceError,
+    UnsupportedReferenceSequencePrefixError,
+    VrsMapError,
+)
 from dcd_mapping.lookup import (
     DataLookupError,
     check_gene_normalizer,
@@ -35,7 +41,7 @@ from dcd_mapping.schemas import (
     VrsVersion,
 )
 from dcd_mapping.transcripts import select_transcripts
-from dcd_mapping.vrs_map import VrsMapError, vrs_map
+from dcd_mapping.vrs_map import vrs_map
 
 _logger = logging.getLogger(__name__)
 
@@ -223,7 +229,12 @@ async def map_scoreset(
                 transcript=transcripts[target_gene],
                 silent=silent,
             )
-    except VrsMapError as e:
+    except (
+        MissingSequenceIdError,
+        UnsupportedReferenceSequencePrefixError,
+        UnsupportedReferenceSequenceNameSpaceError,
+        VrsMapError,
+    ) as e:
         _emit_info(
             f"VRS mapping failed for scoreset {metadata.urn}", silent, logging.ERROR
         )

--- a/src/dcd_mapping/main.py
+++ b/src/dcd_mapping/main.py
@@ -8,32 +8,34 @@ from pathlib import Path
 import click
 from requests import HTTPError
 
-from dcd_mapping.align import AlignmentError, BlatNotFoundError, build_alignment_result
+from dcd_mapping.align import build_alignment_result
 from dcd_mapping.annotate import (
     annotate,
     save_mapped_output_json,
     write_scoreset_mapping_to_json,
 )
 from dcd_mapping.exceptions import (
+    AlignmentError,
+    BlatNotFoundError,
+    DataLookupError,
     MissingSequenceIdError,
+    ResourceAcquisitionError,
+    ScoresetNotSupportedError,
     UnsupportedReferenceSequenceNameSpaceError,
     UnsupportedReferenceSequencePrefixError,
     VrsMapError,
 )
 from dcd_mapping.lookup import (
-    DataLookupError,
     check_gene_normalizer,
     check_seqrepo,
     check_uta,
 )
 from dcd_mapping.mavedb_data import (
-    ScoresetNotSupportedError,
     get_scoreset_metadata,
     get_scoreset_records,
     patch_target_sequence_type,
     with_mavedb_score_set,
 )
-from dcd_mapping.resource_utils import ResourceAcquisitionError
 from dcd_mapping.schemas import (
     ScoreRow,
     ScoresetMapping,

--- a/src/dcd_mapping/mavedb_data.py
+++ b/src/dcd_mapping/mavedb_data.py
@@ -17,11 +17,14 @@ import requests
 from fastapi import HTTPException
 from pydantic import ValidationError
 
-from dcd_mapping.lookup import DataLookupError
+from dcd_mapping.exceptions import (
+    DataLookupError,
+    ResourceAcquisitionError,
+    ScoresetNotSupportedError,
+)
 from dcd_mapping.resource_utils import (
     LOCAL_STORE_PATH,
     MAVEDB_BASE_URL,
-    ResourceAcquisitionError,
     authentication_header,
     http_download,
 )
@@ -45,10 +48,6 @@ __all__ = [
 ]
 
 _logger = logging.getLogger(__name__)
-
-
-class ScoresetNotSupportedError(Exception):
-    """Raise when a score set cannot be mapped because it has characteristics that are not currently supported."""
 
 
 def get_scoreset_urns() -> set[str]:

--- a/src/dcd_mapping/mavedb_data.py
+++ b/src/dcd_mapping/mavedb_data.py
@@ -326,7 +326,7 @@ def get_scoreset_records(
     return _load_scoreset_records(scores_csv, metadata)
 
 
-def correct_target_sequence_type(
+def patch_target_sequence_type(
     metadata: ScoresetMetadata, records: dict
 ) -> ScoresetMetadata:
     """If target sequence type is DNA but all variants are protein-level, change to protein.

--- a/src/dcd_mapping/mavedb_data.py
+++ b/src/dcd_mapping/mavedb_data.py
@@ -329,22 +329,19 @@ def get_scoreset_records(
 def patch_target_sequence_type(
     metadata: ScoresetMetadata, records: dict
 ) -> ScoresetMetadata:
-    """If target sequence type is DNA but all variants are protein-level, change to protein.
+    """If target sequence type is DNA but no nucleotide variants are defined, treat the target as if
+    it were a protein level target.
     This avoids BLAT errors in cases where the target sequence was codon-optimized
     for a non-human organism
     """
     for target_label, target in metadata.target_genes.items():
-        if target.target_sequence_type == TargetSequenceType.DNA:
-            all_protein = True
-            for record in records.get(target_label, []):
-                if record.hgvs_pro == "NA" or not record.hgvs_pro:
-                    all_protein = False
-                    break
-            if all_protein:
-                msg = f"Changing target sequence type for {metadata.urn} target {target_label} from DNA to protein because all variants are protein-level"
-                _logger.info(msg)
-                target.target_sequence = _get_protein_sequence(target.target_sequence)
-                target.target_sequence_type = TargetSequenceType.PROTEIN
+        if target.target_sequence_type == TargetSequenceType.DNA and not any(
+            record.hgvs_nt for record in records.get(target_label, [])
+        ):
+            msg = f"Changing target sequence type for {metadata.urn} target {target_label} from DNA to protein because target only has protein-level variants"
+            _logger.info(msg)
+            target.target_sequence = _get_protein_sequence(target.target_sequence)
+            target.target_sequence_type = TargetSequenceType.PROTEIN
     return metadata
 
 

--- a/src/dcd_mapping/resource_utils.py
+++ b/src/dcd_mapping/resource_utils.py
@@ -18,10 +18,6 @@ if not LOCAL_STORE_PATH.exists():
     LOCAL_STORE_PATH.mkdir(exist_ok=True, parents=True)
 
 
-class ResourceAcquisitionError(Exception):
-    """Raise when resource acquisition fails."""
-
-
 def authentication_header() -> dict | None:
     """Fetch with api key envvar, if available."""
     return {"X-API-key": MAVEDB_API_KEY} if MAVEDB_API_KEY is not None else None

--- a/src/dcd_mapping/resource_utils.py
+++ b/src/dcd_mapping/resource_utils.py
@@ -39,7 +39,7 @@ def http_download(url: str, out_path: Path, silent: bool = True) -> Path:
     if not silent:
         click.echo(f"Downloading {out_path.name} to {out_path.parents[0].absolute()}")
     with requests.get(
-        url, stream=True, timeout=30, headers=authentication_header()
+        url, stream=True, timeout=60, headers=authentication_header()
     ) as r:
         r.raise_for_status()
         total_size = int(r.headers.get("content-length", 0))

--- a/src/dcd_mapping/transcripts.py
+++ b/src/dcd_mapping/transcripts.py
@@ -7,6 +7,7 @@ from Bio.Seq import Seq
 from Bio.SeqUtils import seq1
 from cool_seq_tool.schemas import TranscriptPriority
 
+from dcd_mapping.exceptions import TxSelectError
 from dcd_mapping.lookup import (
     get_chromosome_identifier,
     get_gene_symbol,
@@ -29,13 +30,9 @@ from dcd_mapping.schemas import (
     TxSelectResult,
 )
 
-__all__ = ["select_transcript", "TxSelectError"]
+__all__ = ["select_transcript"]
 
 _logger = logging.getLogger(__name__)
-
-
-class TxSelectError(Exception):
-    """Raise for transcript selection failure."""
 
 
 async def _get_compatible_transcripts(

--- a/src/dcd_mapping/transcripts.py
+++ b/src/dcd_mapping/transcripts.py
@@ -54,7 +54,10 @@ async def _get_compatible_transcripts(
     chromosome = get_chromosome_identifier(aligned_chrom)
     gene_symbol = get_gene_symbol(target_gene)
     if not gene_symbol:
-        raise TxSelectError
+        msg = (
+            f"Unable to find gene symbol for target gene {target_gene.target_gene_name}"
+        )
+        raise TxSelectError(msg)
     transcript_matches = []
     for hit_range in align_result.hit_subranges:
         matches_list = await get_transcripts(
@@ -179,7 +182,8 @@ async def _select_protein_reference(
         if not best_tx:
             best_tx = await _get_longest_compatible_transcript(common_transcripts)
         if not best_tx:
-            raise TxSelectError
+            msg = f"Unable to find matching MANE transcripts for target gene {target_gene.target_gene_name}"
+            raise TxSelectError(msg)
         ref_sequence = get_sequence(best_tx.refseq_prot)
         nm_accession = best_tx.refseq_nuc
         np_accession = best_tx.refseq_prot
@@ -323,19 +327,6 @@ async def select_transcript(
     :param align_result: alignment results
     :return: Transcript description (accession ID, offset, selected sequence, etc)
     """
-    if scoreset_urn.startswith("urn:mavedb:00000097"):
-        _logger.info(
-            "Score sets in urn:mavedb:00000097 are already expressed in full HGVS strings -- using predefined results because additional hard-coding is unnecessary"
-        )
-        return TxSelectResult(
-            nm="NM_007294.3",
-            np="NP_009225.1",
-            start=0,
-            is_full_match=False,
-            transcript_mode=TranscriptPriority.MANE_SELECT,
-            sequence=_get_protein_sequence(target_gene.target_sequence),
-        )
-
     if target_gene.target_gene_category != TargetType.PROTEIN_CODING:
         _logger.debug(
             "%s is regulatory/noncoding -- skipping transcript selection",
@@ -366,7 +357,9 @@ async def select_transcripts(
         * Dict where keys are target labels and values are alignment result objects
     :return: dict where keys are target labels and values are objects describing selected transcript (accession ID, offset, selected sequence, etc)
     """
-    selected_transcripts = {}
+    selected_transcripts: dict[
+        str, TxSelectResult | TxSelectError | KeyError | None
+    ] = {}
     for target_gene in scoreset_metadata.target_genes:
         if scoreset_metadata.target_genes[target_gene].target_accession_id:
             # for accession-based targets, create tx select objects for protein sequence accessions only

--- a/src/dcd_mapping/version.py
+++ b/src/dcd_mapping/version.py
@@ -1,3 +1,3 @@
 """Provide dcd mapping version"""
 
-dcd_mapping_version = "2025.1.0"
+dcd_mapping_version = "2025.2.0"

--- a/src/dcd_mapping/vrs_map.py
+++ b/src/dcd_mapping/vrs_map.py
@@ -20,6 +20,11 @@ from ga4gh.vrs.normalize import normalize
 from mavehgvs.util import parse_variant_strings
 from mavehgvs.variant import Variant
 
+from dcd_mapping.exceptions import (
+    MissingSequenceIdError,
+    UnsupportedReferenceSequenceNameSpaceError,
+    UnsupportedReferenceSequencePrefixError,
+)
 from dcd_mapping.lookup import (
     cdot_rest,
     get_chromosome_identifier,
@@ -37,14 +42,10 @@ from dcd_mapping.schemas import (
 )
 from dcd_mapping.transcripts import TxSelectError
 
-__all__ = ["vrs_map", "VrsMapError"]
+__all__ = ["vrs_map"]
 
 
 _logger = logging.getLogger(__name__)
-
-
-class VrsMapError(Exception):
-    """Raise in case of VRS mapping errors."""
 
 
 def _hgvs_variant_is_valid(hgvs_string: str) -> bool:
@@ -612,11 +613,8 @@ def _map_genomic(
                 error_message=str(e),
             )
     else:
-        return MappedScore(
-            accession_id=row.accession,
-            score=row.score,
-            error_message=f"Reference sequence namespace not supported: {namespace}",
-        )
+        msg = f"Unsupported reference sequence namespace: {namespace}"
+        raise UnsupportedReferenceSequenceNameSpaceError(msg)
 
     return MappedScore(
         accession_id=row.accession,
@@ -789,14 +787,8 @@ def _map_accession(
     variations: list[MappedScore] = []
     sequence_id = metadata.target_accession_id
     if sequence_id is None:
-        return [
-            MappedScore(
-                accession_id=row.accession,
-                score=row.score,
-                error_message="Could not generate mapped allele objects. No sequence id was provided.",
-            )
-            for row in records
-        ]
+        msg = " No target_accession_id was provided by target gene metadata. Target gene metadata must have a target_accession_id to map to VRS."
+        raise MissingSequenceIdError(msg)
 
     store_accession(sequence_id)
 
@@ -815,14 +807,8 @@ def _map_accession(
             hgvs_nt_mappings = _map_genomic(row, sequence_id, align_result)
             variations.append(hgvs_nt_mappings)
     else:
-        [
-            MappedScore(
-                accession_id=row.accession,
-                score=row.score,
-                error_message=f"Unrecognized accession prefix for accession id {metadata.target_accession_id}",
-            )
-            for row in records
-        ]
+        msg = f"Unrecognized accession prefix for accession id: {metadata.target_accession_id}"
+        raise UnsupportedReferenceSequencePrefixError(msg)
 
     return variations
 

--- a/src/dcd_mapping/vrs_map.py
+++ b/src/dcd_mapping/vrs_map.py
@@ -453,8 +453,11 @@ def _map_genomic(
             # if the sequence id starts with SQ, it is a target sequence which is in the ga4gh namespace
             namespace = "ga4gh"
         else:
-            msg = f"Namespace could not be inferred from sequence: {sequence_id}"
-            raise ValueError(msg)
+            return MappedScore(
+                accession_id=row.accession,
+                score=row.score,
+                error_message=f"Namespace could not be inferred from sequence: {sequence_id}",
+            )
 
     if (
         row.hgvs_nt in {"_wt", "_sy", "="}
@@ -609,8 +612,11 @@ def _map_genomic(
                 error_message=str(e),
             )
     else:
-        msg = f"Reference sequence namespace not supported: {namespace}"
-        raise ValueError(msg)
+        return MappedScore(
+            accession_id=row.accession,
+            score=row.score,
+            error_message=f"Reference sequence namespace not supported: {namespace}",
+        )
 
     return MappedScore(
         accession_id=row.accession,
@@ -783,7 +789,14 @@ def _map_accession(
     variations: list[MappedScore] = []
     sequence_id = metadata.target_accession_id
     if sequence_id is None:
-        raise ValueError
+        return [
+            MappedScore(
+                accession_id=row.accession,
+                score=row.score,
+                error_message="Could not generate mapped allele objects. No sequence id was provided.",
+            )
+            for row in records
+        ]
 
     store_accession(sequence_id)
 
@@ -802,8 +815,14 @@ def _map_accession(
             hgvs_nt_mappings = _map_genomic(row, sequence_id, align_result)
             variations.append(hgvs_nt_mappings)
     else:
-        msg = f"Unrecognized accession prefix for accession id {metadata.target_accession_id}"
-        raise ValueError(msg)
+        [
+            MappedScore(
+                accession_id=row.accession,
+                score=row.score,
+                error_message=f"Unrecognized accession prefix for accession id {metadata.target_accession_id}",
+            )
+            for row in records
+        ]
 
     return variations
 
@@ -887,7 +906,7 @@ def vrs_map(
     records: list[ScoreRow],
     transcript: TxSelectResult | TxSelectError | None = None,
     silent: bool = True,
-) -> list[MappedScore] | None:
+) -> list[MappedScore]:
     """Given a description of a MAVE scoreset and an aligned transcript, generate
     the corresponding VRS objects.
 


### PR DESCRIPTION
### Enhancements to error handling:
* Added detailed error messages for cases where accession values cannot be determined during allele or haplotype annotation, replacing generic `ValueError` exceptions (`src/dcd_mapping/annotate.py`). [[1]](diffhunk://#diff-80cb2a97f07b0bfc40eb19abe98b007a9d85f34652197e19a30b1096a28f0041L269-R277) [[2]](diffhunk://#diff-80cb2a97f07b0bfc40eb19abe98b007a9d85f34652197e19a30b1096a28f0041L324-R335)
* Improved error messages for transcript selection failures, including specific reasons for the failure, such as missing gene symbols or matching transcripts (`src/dcd_mapping/transcripts.py`). [[1]](diffhunk://#diff-fb6a30da3e1820798884d5f9fc8322774e0ebf872f1a86bec47a848eb258b815L57-R60) [[2]](diffhunk://#diff-fb6a30da3e1820798884d5f9fc8322774e0ebf872f1a86bec47a848eb258b815L182-R186)
* Added error handling for unsupported sequence namespaces and intronic variants in genomic mapping, returning `MappedScore` objects with appropriate error messages (`src/dcd_mapping/vrs_map.py`). [[1]](diffhunk://#diff-0295e435516bca854a6f27ebee70141e4b90633b060ee294381b07b195941795L456-R483) [[2]](diffhunk://#diff-0295e435516bca854a6f27ebee70141e4b90633b060ee294381b07b195941795L612-R642)

### Improvements to mapping logic:
* Introduced checks for mismatches between the number of mapped scores and total score records, with corresponding error messages (`src/api/routers/map.py`).

### Codebase simplification:
* Removed hard-coded logic for specific datasets, such as manually selecting protein annotations or predefined results for certain score sets (`src/dcd_mapping/annotate.py`, `src/dcd_mapping/transcripts.py`). [[1]](diffhunk://#diff-80cb2a97f07b0bfc40eb19abe98b007a9d85f34652197e19a30b1096a28f0041L522-L526) [[2]](diffhunk://#diff-fb6a30da3e1820798884d5f9fc8322774e0ebf872f1a86bec47a848eb258b815L326-L338)
* Simplified conditional statements by directly assigning error messages without redundant checks (`src/dcd_mapping/annotate.py`). [[1]](diffhunk://#diff-80cb2a97f07b0bfc40eb19abe98b007a9d85f34652197e19a30b1096a28f0041L298-R302) [[2]](diffhunk://#diff-80cb2a97f07b0bfc40eb19abe98b007a9d85f34652197e19a30b1096a28f0041L354-R361)

### Performance and timeout adjustments:
* Increased the HTTP request timeout from 30 to 60 seconds in the `http_download` function to accommodate slower network conditions (`src/dcd_mapping/resource_utils.py`).