### PR TITLE
maintenance: Performance and Logging enhancements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ requires-python = ">=3.11"
 
 dependencies = [
     "agct~=0.1.0",
-    "requests",
     "biopython",
     "tqdm",
     "cdot",
@@ -41,6 +40,7 @@ dependencies = [
     "cool-seq-tool==0.4.0.dev3",
     "ga4gh.vrs==2.0.0-a6",
     "gene_normalizer[etl,pg]==0.3.0-dev2",
+    "httpx~=0.28",
     "pydantic>=2",
     "python-dotenv",
     "setuptools>=68.0",  # tmp -- ensure 3.12 compatibility
@@ -61,7 +61,7 @@ tests = [
     "pytest-mock",
     "pytest-cov",
     "pytest-asyncio",
-    "requests-mock"
+    "respx"
 ]
 dev = [
     "ruff==0.2.0",

--- a/src/api/routers/map.py
+++ b/src/api/routers/map.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from cool_seq_tool.schemas import AnnotationLayer
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
-from requests import HTTPError
+from httpx import HTTPStatusError
 
 from dcd_mapping.align import build_alignment_result
 from dcd_mapping.annotate import (
@@ -117,7 +117,7 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
     # on the target level and on the variant level for variants relative to that target
     # HTTPErrors and DataLookupErrors cause the mapping process to exit because these indicate
     # underlying issues with data providers.
-    except HTTPError as e:
+    except HTTPStatusError as e:
         msg = f"HTTP error occurred during transcript selection: {e}"
         _logger.error(msg)
         raise HTTPException(status_code=500, detail=msg) from e

--- a/src/api/routers/map.py
+++ b/src/api/routers/map.py
@@ -64,6 +64,7 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
         records = get_scoreset_records(metadata, True, store_path)
         metadata = patch_target_sequence_type(metadata, records, force=False)
     except ScoresetNotSupportedError as e:
+        _logger.error("Scoreset not supported for %s: %s", urn, e)
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=None,
@@ -72,6 +73,7 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
         )
     except ResourceAcquisitionError as e:
         msg = f"Unable to acquire resource from MaveDB: {e}"
+        _logger.error(msg)
         raise HTTPException(status_code=500, detail=msg) from e
 
     if not records:
@@ -87,17 +89,21 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
         alignment_results = build_alignment_result(metadata, True)
     except BlatNotFoundError as e:
         msg = "BLAT command appears missing. Ensure it is available on the $PATH or use the environment variable BLAT_BIN_PATH to point to it. See instructions in the README prerequisites section for more."
+        _logger.error("BLAT not found for %s: %s", urn, e)
         raise HTTPException(status_code=500, detail=msg) from e
     except ResourceAcquisitionError as e:
         msg = f"BLAT resource could not be acquired: {e}"
+        _logger.error(msg)
         raise HTTPException(status_code=500, detail=msg) from e
     except AlignmentError as e:
+        _logger.error("Alignment error for %s: %s", urn, e)
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata, error_message=str(e).strip("'")
             ).model_dump(exclude_none=True)
         )
     except ScoresetNotSupportedError as e:
+        _logger.error("Scoreset not supported during alignment for %s: %s", urn, e)
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata, error_message=str(e).strip("'")
@@ -113,9 +119,11 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
     # underlying issues with data providers.
     except HTTPError as e:
         msg = f"HTTP error occurred during transcript selection: {e}"
+        _logger.error(msg)
         raise HTTPException(status_code=500, detail=msg) from e
     except DataLookupError as e:
         msg = f"Data lookup error occurred during transcript selection: {e}"
+        _logger.error(msg)
         raise HTTPException(status_code=500, detail=msg) from e
 
     vrs_results = {}
@@ -134,6 +142,7 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
         UnsupportedReferenceSequencePrefixError,
         MissingSequenceIdError,
     ) as e:
+        _logger.error("VRS mapping error for %s: %s", urn, e)
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata, error_message=str(e).strip("'")
@@ -172,6 +181,7 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
                 VrsVersion.V_2,
             )
     except Exception as e:
+        _logger.error("Unexpected error during annotation for %s: %s", urn, e)
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata, error_message=str(e).strip("'")
@@ -287,6 +297,7 @@ async def map_scoreset(urn: str, store_path: Path | None = None) -> JSONResponse
                         del reference_sequences[target_gene].layers[layer]
 
     except Exception as e:
+        _logger.error("Unexpected error during result assembly for %s: %s", urn, e)
         return JSONResponse(
             content=ScoresetMapping(
                 metadata=metadata, error_message=str(e).strip("'")

--- a/src/dcd_mapping/align.py
+++ b/src/dcd_mapping/align.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from urllib.parse import urlparse
 
-import requests
+import httpx
 from Bio.SearchIO import HSP
 from Bio.SearchIO import parse as parse_blat
 from Bio.SearchIO._model import Hit, QueryResult
@@ -84,7 +84,7 @@ def get_ref_genome_file(
     if not genome_file.exists():
         try:
             http_download(url, genome_file, silent)
-        except requests.HTTPError as e:
+        except httpx.HTTPStatusError as e:
             msg = f"HTTPError when fetching reference genome file from {url}"
             _logger.error(msg)
             raise ResourceAcquisitionError(msg) from e
@@ -378,11 +378,11 @@ def fetch_alignment(
             alignment_results[accession_id] = None
         else:
             url = f"{CDOT_URL}/transcript/{accession_id}"
-            r = requests.get(url, timeout=30)
+            r = httpx.get(url, timeout=30)
 
             try:
                 r.raise_for_status()
-            except requests.HTTPError as e:
+            except httpx.HTTPStatusError as e:
                 msg = f"Received HTTPError from {url} for scoreset {metadata.urn}"
                 _logger.error(msg)
                 raise ResourceAcquisitionError(msg) from e

--- a/src/dcd_mapping/lookup.py
+++ b/src/dcd_mapping/lookup.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from typing import Any
 
 import hgvs
+import httpx
 import polars as pl
-import requests
 from biocommons.seqrepo import SeqRepo
 from biocommons.seqrepo.seqaliasdb.seqaliasdb import sqlite3
 from cdot.hgvs.dataproviders import ChainedSeqFetcher, FastaSeqFetcher, RESTDataProvider
@@ -682,7 +682,7 @@ def get_overlapping_features_for_region(
             url, headers={"Content-Type": "application/json"}
         )
         response.raise_for_status()
-    except requests.RequestException as e:
+    except httpx.HTTPError as e:
         _logger.error(
             "Failed to fetch overlapping features for region %s-%s on chromosome %s: %s",
             start,
@@ -715,7 +715,7 @@ def get_uniprot_sequence(uniprot_id: str) -> str | None:
     :raise HTTPError: if response comes with an HTTP error code
     """
     url = f"https://www.ebi.ac.uk/proteins/api/proteins?accession={uniprot_id.split(':')[1]}&format=json"
-    response = requests.get(url, timeout=30)
+    response = httpx.get(url, timeout=30)
     response.raise_for_status()
     json = response.json()
     return json[0]["sequence"]["sequence"]

--- a/src/dcd_mapping/main.py
+++ b/src/dcd_mapping/main.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 
 import click
-from requests import HTTPError
+from httpx import HTTPStatusError
 
 from dcd_mapping.align import build_alignment_result
 from dcd_mapping.annotate import (
@@ -205,7 +205,7 @@ async def map_scoreset(
     # on the target level and on the variant level for variants relative to that target
     # HTTPErrors and DataLookupErrors cause the mapping process to exit because these indicate
     # underlying issues with data providers.
-    except HTTPError as e:
+    except HTTPStatusError as e:
         _emit_info(
             f"HTTP error occurred during transcript selection: {e}",
             silent,

--- a/src/dcd_mapping/mavedb_data.py
+++ b/src/dcd_mapping/mavedb_data.py
@@ -13,7 +13,7 @@ from functools import wraps
 from pathlib import Path
 from typing import Any
 
-import requests
+import httpx
 from fastapi import HTTPException
 from pydantic import ValidationError
 
@@ -57,7 +57,7 @@ def get_scoreset_urns() -> set[str]:
 
     :return: set of URN strings
     """
-    r = requests.get(
+    r = httpx.get(
         f"{MAVEDB_BASE_URL}/api/v1/experiments/",
         timeout=30,
         headers=authentication_header(),
@@ -101,14 +101,14 @@ def get_human_urns() -> list[str]:
     scoreset_urns = get_scoreset_urns()
     human_scoresets: list[str] = []
     for urn in scoreset_urns:
-        r = requests.get(
+        r = httpx.get(
             f"{MAVEDB_BASE_URL}/api/v1/score-sets/{urn}",
             timeout=30,
             headers=authentication_header(),
         )
         try:
             r.raise_for_status()
-        except requests.exceptions.HTTPError:
+        except httpx.HTTPStatusError:
             _logger.info("Unable to retrieve scoreset data for URN %s", urn)
             continue
         data = r.json()
@@ -156,10 +156,10 @@ def get_raw_scoreset_metadata(
     metadata_file = dcd_mapping_dir / f"{scoreset_urn}_metadata.json"
     if not metadata_file.exists():
         url = f"{MAVEDB_BASE_URL}/api/v1/score-sets/{scoreset_urn}"
-        r = requests.get(url, timeout=30, headers=authentication_header())
+        r = httpx.get(url, timeout=30, headers=authentication_header())
         try:
             r.raise_for_status()
-        except requests.HTTPError as e:
+        except httpx.HTTPStatusError as e:
             msg = f"Received HTTPError from {url} for scoreset {scoreset_urn}"
             _logger.error(msg)
             raise ResourceAcquisitionError(msg) from e
@@ -318,7 +318,7 @@ def get_scoreset_records(
             url = f"{MAVEDB_BASE_URL}/api/v1/score-sets/{metadata.urn}/scores"
             try:
                 http_download(url, scores_csv, silent)
-            except requests.HTTPError as e:
+            except httpx.HTTPStatusError as e:
                 msg = f"HTTPError when fetching scores CSV from {url}"
                 _logger.error(msg)
                 raise ResourceAcquisitionError(msg) from e

--- a/src/dcd_mapping/resource_utils.py
+++ b/src/dcd_mapping/resource_utils.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 
 import click
-import requests
+import httpx
 from tqdm import tqdm
 
 _logger = logging.getLogger(__name__)
@@ -71,13 +71,11 @@ def http_download(url: str, out_path: Path, silent: bool = True) -> Path:
     :param out_path: location to save file to
     :param silent: show TQDM progress bar if true
     :return: Path if download successful
-    :raise requests.HTTPError: if request is unsuccessful
+    :raise httpx.HTTPStatusError: if request is unsuccessful
     """
     if not silent:
         click.echo(f"Downloading {out_path.name} to {out_path.parents[0].absolute()}")
-    with requests.get(
-        url, stream=True, timeout=60, headers=authentication_header()
-    ) as r:
+    with httpx.stream("GET", url, timeout=60, headers=authentication_header()) as r:
         r.raise_for_status()
         total_size = int(r.headers.get("content-length", 0))
         with out_path.open("wb") as h:
@@ -89,12 +87,12 @@ def http_download(url: str, out_path: Path, silent: bool = True) -> Path:
                     desc=out_path.name,
                     ncols=80,
                 ) as progress_bar:
-                    for chunk in r.iter_content(chunk_size=8192):
+                    for chunk in r.iter_bytes(chunk_size=8192):
                         if chunk:
                             h.write(chunk)
                             progress_bar.update(len(chunk))
             else:
-                for chunk in r.iter_content(chunk_size=8192):
+                for chunk in r.iter_bytes(chunk_size=8192):
                     if chunk:
                         h.write(chunk)
     return out_path
@@ -102,7 +100,7 @@ def http_download(url: str, out_path: Path, silent: bool = True) -> Path:
 
 def request_with_backoff(
     url: str, max_retries: int = 5, backoff_factor: float = 0.3, **kwargs
-) -> requests.Response:
+) -> httpx.Response:
     """HTTP GET with exponential backoff only for retryable errors.
 
     Retries on:
@@ -115,9 +113,9 @@ def request_with_backoff(
     attempt = 0
     while attempt < max_retries:
         try:
-            kwargs.setdefault("timeout", 60)  # Default timeout of 10 seconds
-            response = requests.get(url, **kwargs)  # noqa: S113
-        except (requests.Timeout, requests.ConnectionError):
+            kwargs.setdefault("timeout", 60)
+            response = httpx.get(url, **kwargs)
+        except (httpx.TimeoutException, httpx.ConnectError):
             # Retry on transient network failures
             if attempt == max_retries - 1:
                 raise

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-import requests
+import httpx
 
 from dcd_mapping.lookup import get_overlapping_features_for_region
 
@@ -95,7 +95,7 @@ def test_get_overlapping_features_for_region_error():
 
         def raise_for_status(self):
             msg = f"HTTP {self.status_code} Error"
-            raise requests.RequestException(msg)
+            raise httpx.HTTPError(msg)
 
     with (
         patch("dcd_mapping.lookup.request_with_backoff", return_value=ErrorResponse()),

--- a/tests/test_mavedb_data.py
+++ b/tests/test_mavedb_data.py
@@ -3,8 +3,9 @@ import json
 import shutil
 from pathlib import Path
 
+import httpx
 import pytest
-import requests_mock
+import respx
 
 from dcd_mapping.mavedb_data import get_scoreset_metadata, get_scoreset_records
 
@@ -32,10 +33,9 @@ def test_get_scoreset_metadata(
     resources_data_dir: Path, scoreset_metadata_response: dict
 ):
     urn = "urn:mavedb:00000093-a-1"
-    with requests_mock.Mocker() as m:
-        m.get(
-            f"https://api.mavedb.org/api/v1/score-sets/{urn}",
-            json=scoreset_metadata_response[urn],
+    with respx.mock:
+        respx.get(f"https://api.mavedb.org/api/v1/score-sets/{urn}").mock(
+            return_value=httpx.Response(200, json=scoreset_metadata_response[urn])
         )
         scoreset_metadata = get_scoreset_metadata(
             urn, dcd_mapping_dir=resources_data_dir
@@ -62,17 +62,15 @@ def test_get_scoreset_records(
     urn = "urn:mavedb:00000093-a-1"
     with (fixture_data_dir / f"{urn}_scores.csv").open() as f:
         scores_csv_text = f.read()
-    with requests_mock.Mocker() as m:
-        m.get(
-            f"https://api.mavedb.org/api/v1/score-sets/{urn}",
-            json=scoreset_metadata_response[urn],
+    with respx.mock:
+        respx.get(f"https://api.mavedb.org/api/v1/score-sets/{urn}").mock(
+            return_value=httpx.Response(200, json=scoreset_metadata_response[urn])
         )
         scoreset_metadata = get_scoreset_metadata(
             urn, dcd_mapping_dir=resources_data_dir
         )
-        m.get(
-            f"https://api.mavedb.org/api/v1/score-sets/{urn}/scores",
-            text=scores_csv_text,
+        respx.get(f"https://api.mavedb.org/api/v1/score-sets/{urn}/scores").mock(
+            return_value=httpx.Response(200, text=scores_csv_text)
         )
         scoreset_records = get_scoreset_records(
             scoreset_metadata, dcd_mapping_dir=resources_data_dir

--- a/tests/test_resource_utils.py
+++ b/tests/test_resource_utils.py
@@ -3,8 +3,8 @@
 from contextlib import ExitStack
 from unittest import mock
 
+import httpx
 import pytest
-import requests
 
 from dcd_mapping.resource_utils import request_with_backoff
 
@@ -16,8 +16,10 @@ class _DummyResponse:
 
     def raise_for_status(self):
         if not (200 <= self.status_code < 300):
-            msg = f"HTTP {self.status_code}"
-            raise requests.HTTPError(msg)
+            request = httpx.Request("GET", "http://example.com")
+            response = httpx.Response(self.status_code, request=request)
+            msg = f"HTTP {self.status_code} Error"
+            raise httpx.HTTPStatusError(msg, request=request, response=response)
 
 
 def _sequence_side_effect(values):
@@ -36,7 +38,7 @@ def _sequence_side_effect(values):
 def test_success_200_returns_response():
     dummy = _DummyResponse(200)
     with mock.patch(
-        "dcd_mapping.resource_utils.requests.get", return_value=dummy
+        "dcd_mapping.resource_utils.httpx.get", return_value=dummy
     ) as get_mock:
         resp = request_with_backoff("http://example.com/resource")
         assert resp is dummy
@@ -44,12 +46,12 @@ def test_success_200_returns_response():
 
 
 def test_timeout_then_success_retries_with_backoff():
-    first_exc = requests.Timeout("timeout")
+    first_exc = httpx.TimeoutException("timeout")
     second_resp = _DummyResponse(200)
     with ExitStack() as stack:
         get_mock = stack.enter_context(
             mock.patch(
-                "dcd_mapping.resource_utils.requests.get",
+                "dcd_mapping.resource_utils.httpx.get",
                 side_effect=_sequence_side_effect([first_exc, second_resp]),
             )
         )
@@ -64,18 +66,18 @@ def test_timeout_then_success_retries_with_backoff():
 
 
 def test_connection_error_until_max_raises():
-    seq = [requests.ConnectionError("conn err")] * 5
+    seq = [httpx.ConnectError("conn err")] * 5
     with ExitStack() as stack:
         stack.enter_context(
             mock.patch(
-                "dcd_mapping.resource_utils.requests.get",
+                "dcd_mapping.resource_utils.httpx.get",
                 side_effect=_sequence_side_effect(seq),
             )
         )
         sleep_mock = stack.enter_context(
             mock.patch("dcd_mapping.resource_utils.time.sleep")
         )
-        with pytest.raises(requests.ConnectionError):
+        with pytest.raises(httpx.ConnectError):
             request_with_backoff(
                 "http://example.com/resource", max_retries=5, backoff_factor=0.1
             )
@@ -90,7 +92,7 @@ def test_5xx_then_success_retries():
     with ExitStack() as stack:
         get_mock = stack.enter_context(
             mock.patch(
-                "dcd_mapping.resource_utils.requests.get",
+                "dcd_mapping.resource_utils.httpx.get",
                 side_effect=_sequence_side_effect(seq),
             )
         )
@@ -108,14 +110,14 @@ def test_5xx_until_max_raises_http_error():
     with ExitStack() as stack:
         stack.enter_context(
             mock.patch(
-                "dcd_mapping.resource_utils.requests.get",
+                "dcd_mapping.resource_utils.httpx.get",
                 side_effect=_sequence_side_effect(seq),
             )
         )
         sleep_mock = stack.enter_context(
             mock.patch("dcd_mapping.resource_utils.time.sleep")
         )
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(httpx.HTTPStatusError):
             request_with_backoff(
                 "http://example.com/resource", max_retries=3, backoff_factor=0.1
             )
@@ -129,7 +131,7 @@ def test_429_with_retry_after_header_respected():
     with ExitStack() as stack:
         get_mock = stack.enter_context(
             mock.patch(
-                "dcd_mapping.resource_utils.requests.get",
+                "dcd_mapping.resource_utils.httpx.get",
                 side_effect=_sequence_side_effect([resp1, resp2]),
             )
         )
@@ -148,7 +150,7 @@ def test_429_with_bad_retry_after_falls_back_to_backoff():
     with ExitStack() as stack:
         stack.enter_context(
             mock.patch(
-                "dcd_mapping.resource_utils.requests.get",
+                "dcd_mapping.resource_utils.httpx.get",
                 side_effect=_sequence_side_effect([resp1, resp2]),
             )
         )
@@ -164,12 +166,12 @@ def test_non_retryable_4xx_raises_immediately():
     resp = _DummyResponse(404)
     with ExitStack() as stack:
         stack.enter_context(
-            mock.patch("dcd_mapping.resource_utils.requests.get", return_value=resp)
+            mock.patch("dcd_mapping.resource_utils.httpx.get", return_value=resp)
         )
         sleep_mock = stack.enter_context(
             mock.patch("dcd_mapping.resource_utils.time.sleep")
         )
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(httpx.HTTPStatusError):
             request_with_backoff("http://example.com/resource")
         # no sleeps for non-retryable errors
         sleep_mock.assert_not_called()
@@ -179,7 +181,7 @@ def test_exhausted_retries_without_response_raises_request_exception():
     # The only way to trigger the terminal state in the function is to not even
     # attempt a request (max_retries=0)
     with mock.patch(
-        "dcd_mapping.resource_utils.requests.get", return_value=_DummyResponse(500)
+        "dcd_mapping.resource_utils.httpx.get", return_value=_DummyResponse(500)
     ), mock.patch("dcd_mapping.resource_utils.time.sleep"), pytest.raises(
         Exception  # noqa: PT011
     ) as exc:
@@ -190,7 +192,7 @@ def test_exhausted_retries_without_response_raises_request_exception():
 def test_kwargs_are_passed_through_to_requests_get():
     dummy = _DummyResponse(200)
     with mock.patch(
-        "dcd_mapping.resource_utils.requests.get", return_value=dummy
+        "dcd_mapping.resource_utils.httpx.get", return_value=dummy
     ) as get_mock:
         request_with_backoff(
             "http://example.com/resource", headers={"X-Test": "1"}, params={"q": "x"}


### PR DESCRIPTION
This pull request migrates the codebase from using the `requests` library to `httpx` for HTTP requests, both in the main application and in the test suite. Additionally, it improves error logging throughout the mapping and data retrieval code, and updates the testing dependencies to use `respx` instead of `requests-mock`.

When querying the Ensembl API, the requests library was taking 30-70s per request, while curl was rendering results in less than a second. This migration reduces ensembl wait times and speeds up mapping jobs.

**HTTP library migration:**

* Replaced all usage of `requests` with `httpx` across the codebase, including imports, request calls, exception handling, and documentation [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L36-R43) [[2]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67L8-R8) [[3]](diffhunk://#diff-6aab8d29973080bad0ade79de311883b77cbb21ba3e8257674bae115b528ea8cL10-R10) [[4]](diffhunk://#diff-3cc898bcf4708058190ae7ad15b56a643a5ed49cc00a0172f282f6d757a2115dR17-L18) [[5]](diffhunk://#diff-694dbb5ba9ebbc18a37a2d407dccd3a43e768cdfd2fd4bdd00246602edf6dfe5L9-R9) [[6]](diffhunk://#diff-d9bba7c8ae7d9346b6ae8e80165e7c5f29f6f83c5a61112142319d523c1f23d2L16-R16) [[7]](diffhunk://#diff-8a42270c2b50babb2b0c1f0785782d036d93ba54906001c13ab2b139ba71afbfL8-R8) [[8]](diffhunk://#diff-f1d94322777eaa3fe277751e8aba5a35be5a841989dc864794343ee3156a525eL5-R5).
* Updated exception handling to use `httpx.HTTPStatusError` and `httpx.HTTPError` where appropriate, replacing `requests` equivalents [[1]](diffhunk://#diff-6aab8d29973080bad0ade79de311883b77cbb21ba3e8257674bae115b528ea8cL87-R87) [[2]](diffhunk://#diff-6aab8d29973080bad0ade79de311883b77cbb21ba3e8257674bae115b528ea8cL381-R385) [[3]](diffhunk://#diff-3cc898bcf4708058190ae7ad15b56a643a5ed49cc00a0172f282f6d757a2115dL685-R685) [[4]](diffhunk://#diff-d9bba7c8ae7d9346b6ae8e80165e7c5f29f6f83c5a61112142319d523c1f23d2L104-R111) [[5]](diffhunk://#diff-d9bba7c8ae7d9346b6ae8e80165e7c5f29f6f83c5a61112142319d523c1f23d2L159-R162) [[6]](diffhunk://#diff-d9bba7c8ae7d9346b6ae8e80165e7c5f29f6f83c5a61112142319d523c1f23d2L321-R321) [[7]](diffhunk://#diff-8a42270c2b50babb2b0c1f0785782d036d93ba54906001c13ab2b139ba71afbfL74-R78) [[8]](diffhunk://#diff-8a42270c2b50babb2b0c1f0785782d036d93ba54906001c13ab2b139ba71afbfL118-R118) [[9]](diffhunk://#diff-694dbb5ba9ebbc18a37a2d407dccd3a43e768cdfd2fd4bdd00246602edf6dfe5L208-R208) [[10]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67L114-R126).

**Error handling and logging improvements:**

* Added detailed logging for various error cases in `map_scoreset` to aid debugging and operational visibility [[1]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67R67) [[2]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67R76) [[3]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67R92-R106) [[4]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67L114-R126) [[5]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67R145) [[6]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67R184) [[7]](diffhunk://#diff-e87d56e38cde322f3c5dfd987f00286be6ca50064162052ca20ff93b56c58c67R300).

**Testing and dependency updates:**

* Switched test dependencies from `requests-mock` to `respx` for mocking `httpx` requests in tests [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L64-R64) [[2]](diffhunk://#diff-c2923b9413f1a9d5ffe259852abfc15b6448a91dafa70000609606b71d05c100R6-R8).
* Updated test code to use `respx` and `httpx` in place of `requests-mock` and `requests` [[1]](diffhunk://#diff-c2923b9413f1a9d5ffe259852abfc15b6448a91dafa70000609606b71d05c100L35-R38) [[2]](diffhunk://#diff-f1d94322777eaa3fe277751e8aba5a35be5a841989dc864794343ee3156a525eL98-R98).

**Supporting changes for HTTPX:**

* Updated streaming and chunked download logic to use `httpx` methods such as `iter_bytes` instead of `requests`' `iter_content`.
* Updated function signatures and docstrings to reflect the switch to `httpx` types and exceptions [[1]](diffhunk://#diff-8a42270c2b50babb2b0c1f0785782d036d93ba54906001c13ab2b139ba71afbfL74-R78) [[2]](diffhunk://#diff-8a42270c2b50babb2b0c1f0785782d036d93ba54906001c13ab2b139ba71afbfL118-R118).

**Dependency management:**

* Added `httpx~=0.28` to the main dependencies in `pyproject.toml` and removed `requests`.
* Added `respx` to the test dependencies and removed `requests-mock`.