### PR TITLE
ci: Add Coveralls Reporting

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,21 +1,23 @@
 name: Checks
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - mavedb-main
+      - mavedb-dev
+  pull_request:
 jobs:
   test:
-    name: test py${{ matrix.python-version }}
+    name: test py3.11
     runs-on: ubuntu-latest
     env:
       MAVEDB_BASE_URL: https://api.mavedb.org
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -23,7 +25,14 @@ jobs:
 
       - name: Run tests
         # only run tests known to work in CI
-        run: python3 -m pytest tests/test_mavedb_data.py
+        run: |
+          mkdir -p coverage
+          python3 -m pytest tests/test_mavedb_data.py --cov-report=lcov:coverage/lcov.info
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          path-to-lcov: coverage/lcov.info
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +41,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: "3.11"
 
       - name: Install dependencies
         run: python3 -m pip install ".[dev]"

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage/
 *.cover
 *.py,cover
 .hypothesis/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
- Restrict push triggers to mavedb-main and mavedb-dev branches
- Drop the python-version matrix in favour of a fixed py3.11 job
- Add pytest --cov-report=lcov and upload coverage to Coveralls via coverallsapp/github-action@v2
- Ignore generated coverage/ directory in .gitignore
- Remove py3.10 classifier from pyproject.toml