### PR TITLE
fix: Remove underscore from check for Ensembl Protein ID

### DIFF
--- a/src/dcd_mapping/transcripts.py
+++ b/src/dcd_mapping/transcripts.py
@@ -438,7 +438,7 @@ async def select_transcripts(
                 target_gene
             ].target_accession_id
             # TODO create full list of possible protein accession prefixes
-            if accession_id.startswith(("NP_", "ENSP_")):
+            if accession_id.startswith(("NP_", "ENSP")):
                 # TODO make sequence field optional instead of leaving blank here?
                 selected_transcripts[target_gene] = TxSelectResult(
                     np=accession_id,


### PR DESCRIPTION
There is no underscore in Ensembl IDs so removing it from the ID prefix check in transcripts module.